### PR TITLE
Adds karma-coverage plugin and generates Cobertura reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /dest/
 /test_results/
+/coverage/

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "karma-chai": "~0.1.0",
     "karma-chrome-launcher": "^0.2.0",
     "karma-cli": "^0.1.0",
+    "karma-coverage": "^0.5.1",
     "karma-junit-reporter": "^0.3.4",
     "karma-mocha": "~0.2.0",
     "karma-phantomjs-launcher": "~0.2.1",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -11,6 +11,7 @@ module.exports = function(config) {
 			, 'karma-chrome-launcher'
 			, 'karma-browserify'
 			, 'karma-junit-reporter'
+			, 'karma-coverage'
 			, 'karma-mocha'
 			, 'karma-sinon'
 			, 'karma-chai'
@@ -43,7 +44,7 @@ module.exports = function(config) {
 		// preprocess matching files before serving them to the browser
 		// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
 		preprocessors: {
-			'src/**/*.js' : ['browserify']
+			'src/**/*.js' : ['coverage', 'browserify']
 			//, '../src/**/*.jsx' : ['browserify']
 		},
 
@@ -64,12 +65,18 @@ module.exports = function(config) {
 			outputDir: '../test_results'
 		},
 
+		coverageReporter: {
+			type : 'cobertura'
+			, dir : '../coverage'
+		},
+		
 		// test results reporter to use
 		// possible values: 'dots', 'progress'
 		// available reporters: https://npmjs.org/browse/keyword/karma-reporter
 		reporters: [
 			'progress'
 			, 'junit'
+			, 'coverage'
 		],
 
 


### PR DESCRIPTION
Adds the `karma-coverage` plugin to instrument JS code with Istanbul and generates Cobertura reports during tests.

Note: I still haven't figured out well how to make Istanbul and Browserify coexist. Coverage reports are currently empty.
