### PR TITLE
Generates coverage reports

### DIFF
--- a/src/js/test.js
+++ b/src/js/test.js
@@ -1,3 +1,3 @@
-function foo() {
+module.exports = function foo() {
 	return 1;
-}
+};

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -44,7 +44,8 @@ module.exports = function(config) {
 		// preprocess matching files before serving them to the browser
 		// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
 		preprocessors: {
-			'src/**/*.js' : ['coverage', 'browserify']
+			'../src/**/*.js' : ['browserify', 'coverage']
+			,'./unit/**/*.js' : ['browserify']
 			//, '../src/**/*.jsx' : ['browserify']
 		},
 

--- a/test/unit/test.spec.js
+++ b/test/unit/test.spec.js
@@ -1,3 +1,5 @@
+var foo = require('../../src/js/test');
+
 describe('function foo', function() {
 	it('returns 1', function() {
 		expect(foo()).to.equal(1);


### PR DESCRIPTION
Moved `coverage` preprocessor after `browserify` and fixed paths.
